### PR TITLE
Standardize admin pages

### DIFF
--- a/admin/cupons.php
+++ b/admin/cupons.php
@@ -65,16 +65,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['toggle_status'])) {
 // Buscar todos os cupons
 $stmt = $conn->query("SELECT * FROM cupons ORDER BY data_criacao DESC");
 $cupons = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Cupons - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
+$page_title = 'Gerenciar Cupons';
+include '../includes/admin_header.php';
+?>
+<style>
         .cupom-form {
             max-width: 600px;
             margin: 20px auto;
@@ -121,23 +116,6 @@ $cupons = $stmt->fetchAll(PDO::FETCH_ASSOC);
         }
     </style>
 </head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan - Admin</h1>
-            </div>
-            <div class="nav-links">
-                <a href="index.php">Dashboard</a>
-                <a href="transacoes.php">Transações</a>
-                <a href="usuarios.php">Usuários</a>
-                <a href="pacotes.php">Pacotes</a>
-                <a href="cupons.php">Cupons</a>
-                <a href="../index.php">Voltar ao Site</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
 
     <main>
         <section class="admin-content">
@@ -264,8 +242,4 @@ $cupons = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </section>
     </main>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
-</body>
-</html> 
+<?php include '../includes/admin_footer.php'; ?>

--- a/admin/gerenciar_imagens.php
+++ b/admin/gerenciar_imagens.php
@@ -54,16 +54,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // Buscar pacotes
 $stmt = $conn->query("SELECT * FROM pacotes_wcoin ORDER BY nome");
 $pacotes = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Imagens - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
+$page_title = 'Gerenciar Imagens';
+include '../includes/admin_header.php';
+?>
+<style>
         .admin-container {
             max-width: 1200px;
             margin: 0 auto;
@@ -168,20 +163,6 @@ $pacotes = $stmt->fetchAll(PDO::FETCH_ASSOC);
             color: #f44336;
         }
     </style>
-</head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan</h1>
-            </div>
-            <div class="nav-links">
-                <a href="../index.php">Início</a>
-                <a href="index.php">Painel Admin</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
 
     <main class="admin-container">
         <div class="admin-header">
@@ -228,8 +209,4 @@ $pacotes = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </div>
     </main>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
-</body>
-</html> 
+<?php include '../includes/admin_footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -22,84 +22,10 @@ $stmt = $conn->query("
     LIMIT 5
 ");
 $ultimas_transacoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Painel Administrativo - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
-        .dashboard-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 20px;
-            margin-bottom: 30px;
-        }
-        .stat-card {
-            background: rgba(255, 255, 255, 0.1);
-            padding: 20px;
-            border-radius: 8px;
-            text-align: center;
-        }
-        .stat-card h3 {
-            margin: 0;
-            color: #4CAF50;
-        }
-        .stat-card p {
-            margin: 10px 0 0;
-            font-size: 24px;
-            font-weight: bold;
-        }
-        .ultimas-transacoes {
-            background: rgba(255, 255, 255, 0.1);
-            padding: 20px;
-            border-radius: 8px;
-        }
-        .transacoes-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin-top: 20px;
-        }
-        .transacoes-table th,
-        .transacoes-table td {
-            padding: 12px;
-            text-align: left;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        }
-        .transacoes-table th {
-            background: rgba(0, 0, 0, 0.2);
-        }
-        .status-badge {
-            padding: 4px 8px;
-            border-radius: 4px;
-            font-size: 14px;
-        }
-        .status-aguardando { background: #FFA000; }
-        .status-pago { background: #4CAF50; }
-        .status-cancelado { background: #f44336; }
-        .status-entregue { background: #2196F3; }
-    </style>
-</head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan - Admin</h1>
-            </div>
-            <div class="nav-links">
-                <a href="index.php">Dashboard</a>
-                <a href="transacoes.php">Transações</a>
-                <a href="usuarios.php">Usuários</a>
-                <a href="pacotes.php">Pacotes</a>
-                <a href="cupons.php">Cupons</a>
-                <a href="../index.php">Voltar ao Site</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
+$page_title = 'Painel Administrativo';
+include '../includes/admin_header.php';
+?>
 
     <main>
         <section class="admin-content">
@@ -161,8 +87,4 @@ $ultimas_transacoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </section>
     </main>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
-</body>
-</html> 
+<?php include '../includes/admin_footer.php'; ?>

--- a/admin/pacotes.php
+++ b/admin/pacotes.php
@@ -278,16 +278,11 @@ $pacotes = $stmt->fetchAll(PDO::FETCH_ASSOC);
 // Atualizar todos os pacotes para não serem mais populares por padrão
 $stmt = $conn->prepare("UPDATE pacotes_wcoin SET mais_popular = 0 WHERE mais_popular IS NULL");
 $stmt->execute();
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Pacotes - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
+$page_title = 'Gerenciar Pacotes';
+include '../includes/admin_header.php';
+?>
+<style>
         .admin-container {
             max-width: 1200px;
             margin: 0 auto;
@@ -525,24 +520,6 @@ $stmt->execute();
             padding: 8px 16px;
         }
     </style>
-</head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan</h1>
-            </div>
-            <div class="nav-links">
-                <a href="index.php">Dashboard</a>
-                <a href="transacoes.php">Transações</a>
-                <a href="usuarios.php">Usuários</a>
-                <a href="pacotes.php">Pacotes</a>
-                <a href="cupons.php">Cupons</a>
-                <a href="../index.php">Voltar ao Site</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
 
     <main class="admin-container">
         <div class="admin-header">
@@ -667,9 +644,7 @@ $stmt->execute();
         </div>
     </div>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
+<?php include '../includes/admin_footer.php'; ?>
 
     <script>
         function abrirModal(tipo, dados = null) {
@@ -724,5 +699,3 @@ $stmt->execute();
             }
         }
     </script>
-</body>
-</html> 

--- a/admin/transacoes.php
+++ b/admin/transacoes.php
@@ -58,33 +58,10 @@ $stmt = $conn->query("
     ORDER BY t.data_transacao DESC
 ");
 $transacoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Transações - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-</head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan - Admin</h1>
-            </div>
-            <div class="nav-links">
-                <a href="index.php">Dashboard</a>
-                <a href="transacoes.php">Transações</a>
-                <a href="usuarios.php">Usuários</a>
-                <a href="pacotes.php">Pacotes</a>
-                <a href="cupons.php">Cupons</a>
-                <a href="../index.php">Voltar ao Site</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
+$page_title = 'Gerenciar Transações';
+include '../includes/admin_header.php';
+?>
 
     <main>
         <section class="gerenciar-transacoes">
@@ -153,9 +130,7 @@ $transacoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </section>
     </main>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
+<?php include '../includes/admin_footer.php'; ?>
 
     <script>
     function mostrarKeys(transacaoId) {
@@ -163,5 +138,3 @@ $transacoes = $stmt->fetchAll(PDO::FETCH_ASSOC);
         alert('Funcionalidade de visualização de keys será implementada em breve.');
     }
     </script>
-</body>
-</html> 

--- a/admin/usuarios.php
+++ b/admin/usuarios.php
@@ -102,16 +102,11 @@ $stmt = $conn->query("
     ORDER BY u.nome
 ");
 $usuarios = $stmt->fetchAll(PDO::FETCH_ASSOC);
-?>
 
-<!DOCTYPE html>
-<html lang="pt-BR">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gerenciar Usuários - Credits Zaidan</title>
-    <link rel="stylesheet" href="../assets/css/style.css">
-    <style>
+$page_title = 'Gerenciar Usuários';
+include '../includes/admin_header.php';
+?>
+<style>
         .usuarios-table {
             width: 100%;
             border-collapse: collapse;
@@ -170,24 +165,6 @@ $usuarios = $stmt->fetchAll(PDO::FETCH_ASSOC);
             border: 1px solid rgba(255, 255, 255, 0.1);
         }
     </style>
-</head>
-<body class="dark-theme">
-    <header>
-        <nav>
-            <div class="logo">
-                <h1>Credits Zaidan - Admin</h1>
-            </div>
-            <div class="nav-links">
-                <a href="index.php">Dashboard</a>
-                <a href="transacoes.php">Transações</a>
-                <a href="usuarios.php">Usuários</a>
-                <a href="pacotes.php">Pacotes</a>
-                <a href="cupons.php">Cupons</a>
-                <a href="../index.php">Voltar ao Site</a>
-                <a href="../logout.php">Sair</a>
-            </div>
-        </nav>
-    </header>
 
     <main>
         <section class="gerenciar-usuarios">
@@ -307,8 +284,4 @@ $usuarios = $stmt->fetchAll(PDO::FETCH_ASSOC);
         </section>
     </main>
 
-    <footer>
-        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
-    </footer>
-</body>
-</html> 
+<?php include '../includes/admin_footer.php'; ?>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,103 @@
+/* Shared admin styles */
+.admin .nav-links a {
+    color: var(--text-color);
+    text-decoration: none;
+    margin-left: 1rem;
+    transition: color 0.3s;
+}
+.admin .nav-links a:hover {
+    color: var(--accent-color);
+}
+
+.admin-content,
+.admin-container {
+    max-width: 1200px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+.admin-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+.admin-table th,
+.admin-table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.admin-table th {
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.btn {
+    padding: 6px 12px;
+    border-radius: 4px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+.btn-primary { background: #4CAF50; color: #fff; }
+.btn-danger { background: #f44336; color: #fff; }
+.btn:hover { opacity: 0.9; }
+
+.status-badge {
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+}
+.status-aguardando { background: #FFA000; }
+.status-pago { background: #4CAF50; }
+.status-cancelado { background: #f44336; }
+.status-entregue { background: #2196F3; }
+.status-ativo { background: #4CAF50; }
+.status-inativo { background: #f44336; }
+.role-admin { background: #9C27B0; }
+.role-user { background: #2196F3; }
+.ban-badge { background: #FF5722; padding: 4px 8px; border-radius: 4px; font-size: 14px; }
+.dashboard-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+.stat-card {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+.stat-card h3 {
+    margin: 0;
+    color: #4CAF50;
+}
+.stat-card p {
+    margin: 10px 0 0;
+    font-size: 24px;
+    font-weight: bold;
+}
+.ultimas-transacoes {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 20px;
+    border-radius: 8px;
+}
+.transacoes-table,
+.usuarios-table,
+.cupons-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+.transacoes-table th, .transacoes-table td,
+.usuarios-table th, .usuarios-table td,
+.cupons-table th, .cupons-table td {
+    padding: 12px;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.transacoes-table th,
+.usuarios-table th,
+.cupons-table th {
+    background: rgba(0, 0, 0, 0.2);
+}

--- a/includes/admin_footer.php
+++ b/includes/admin_footer.php
@@ -1,0 +1,5 @@
+    <footer>
+        <p>&copy; 2024 Credits Zaidan - Todos os direitos reservados</p>
+    </footer>
+</body>
+</html>

--- a/includes/admin_header.php
+++ b/includes/admin_header.php
@@ -1,0 +1,27 @@
+<?php if (!isset($page_title)) { $page_title = 'Admin'; } ?>
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo htmlspecialchars($page_title); ?> - Credits Zaidan</title>
+    <link rel="stylesheet" href="../assets/css/style.css">
+    <link rel="stylesheet" href="../assets/css/admin.css">
+</head>
+<body class="dark-theme admin">
+    <header>
+        <nav>
+            <div class="logo">
+                <h1>Credits Zaidan - Admin</h1>
+            </div>
+            <div class="nav-links">
+                <a href="index.php">Dashboard</a>
+                <a href="transacoes.php">Transações</a>
+                <a href="usuarios.php">Usuários</a>
+                <a href="pacotes.php">Pacotes</a>
+                <a href="cupons.php">Cupons</a>
+                <a href="../index.php">Voltar ao Site</a>
+                <a href="../logout.php">Sair</a>
+            </div>
+        </nav>
+    </header>


### PR DESCRIPTION
## Summary
- add shared admin styles
- add reusable admin header and footer
- update admin pages to use the new includes

## Testing
- `php -l admin/index.php`
- `php -l admin/transacoes.php`
- `php -l admin/usuarios.php`
- `php -l admin/pacotes.php`
- `php -l admin/cupons.php`
- `php -l admin/gerenciar_imagens.php`
- `php -l includes/admin_header.php`
- `php -l includes/admin_footer.php`


------
https://chatgpt.com/codex/tasks/task_e_688410efae9883278dab64f3f762a255